### PR TITLE
Fix Hugo build: rename removed _build front matter key to build

### DIFF
--- a/content/blog/2022-06-22-designing-mtu.md
+++ b/content/blog/2022-06-22-designing-mtu.md
@@ -7,7 +7,7 @@ draft: true
 image: ""
 imagealt: ""
 abstract: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec nec gravida dolor, sed euismod odio."
-_build:
+build:
   list: never
   render: never
 ---


### PR DESCRIPTION
The _build front matter key was deprecated in Hugo 0.145.0 and removed entirely by 0.161.1 (the pinned version), causing the Docker build to fail with a hard error. Rename to the current `build` key.